### PR TITLE
memorizeについて

### DIFF
--- a/lib/util/memorize.ts
+++ b/lib/util/memorize.ts
@@ -1,0 +1,20 @@
+export const memorize: <T>(fn: () => T) => () => T = (fn) => {
+  let memorized = false;
+
+  let result:unknown;
+
+  return () => {
+    if (memorized) {
+      return result as ReturnType<typeof fn>;
+    } else {
+      result = fn();
+      memorized = true;
+
+      // メモリを解放するため
+      //@ts-ignore
+      fn = undefined;
+
+      return result as ReturnType<typeof fn>;
+    }
+  };
+};

--- a/playground/memorize_play.ts
+++ b/playground/memorize_play.ts
@@ -1,0 +1,33 @@
+import { memorize } from "../lib/util/memorize.ts";
+
+const hoge = () => {
+  return "hoge";
+};
+
+console.log("----not memorize----");
+
+console.log(hoge);
+
+console.log(hoge())
+
+console.log(hoge);
+
+console.log("-----memorize ------");
+
+console.log(hoge);
+
+const fac = memorize(hoge);
+
+console.log("----exec first time-----")
+
+console.log(fac, fac());
+
+console.log(hoge);
+
+console.log("----exec second time-----")
+
+console.log(fac, fac());
+
+console.log(hoge); // hoge must be undefined
+
+


### PR DESCRIPTION
いわゆるメモ化という奴

この場合恐らく内部状態を持たない && 引数を持たない, つまりどう実行しても返り値が同じになる関数は, なんども再評価してしまうのは無駄なので最初に実行した時その値を保持しておいて2回目以降はそれを返せばいいじゃないという奴.

さらに引数に渡す `fn` は fn = undefinedとしてあげることで, 明示的にメモリを解放してあげてる.
これは関数にObjectを引数として渡して, その中で引数のObjectを操作したら渡したやつまで変わっちゃってるやつと原理的には一緒.